### PR TITLE
Feature/calendar registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,7 @@ jobs:
               exit 1
           fi
   publish-docs:
-    name: foo
+    name: Publish docs to GH Pages.
     needs: build-and-publish-pypi
     runs-on: ubuntu-latest
     environment:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -4,40 +4,144 @@ icon: lucide/cog
 
 # Advanced usage
 
-## Adding an extended calendar for a new exchange
+## Registering a new calendar
 
-The helper function `extend_class` (in `exchange_calendars_extensions.holiday_calendar`) creates an extended calendar
-class from any existing exchange calendar class:
+In [exchange-calendars](https://pypi.org/project/exchange-calendars/), you can use `register_calendar()` and
+`register_calendar_type()` to register new exchange
+calendar instances and types, and `register_calendar_alias()` to make an existing instance/type available under a
+different name.
+
+This functionality naturally carries over to when the extensions provided by this package are applied
+via `apply_extensions()`.
+
+### Calendar instances
+
+When a plain exchange calendar *instance* is registered, it is not automatically extended. This is because extension
+works at the class level to derive extended classes with the additional properties from the plain ones.
 
 ```python
+import exchange_calendars as ec
+import exchange_calendars_extensions as ecx
+
+c0 = ec.get_calendar("XLON")  # Plain calendar instance.
+
+assert isinstance(c0, ec.ExchangeCalendar)
+assert not isinstance(c0, ecx.ExtendedExchangeCalendar)
+
+ecx.apply_extensions()
+
+# Register the instance under a different name.
+ec.register_calendar("TEST", c0)
+
+c = ec.get_calendar("TEST")
+
+# Should be identical to the registered instance.
+assert c is c0
+
+ecx.remove_extensions()
+
+c = ec.get_calendar("TEST")
+
+# Should still be identical to the registered instance.
+assert c is c0
+```
+
+!!! warning
+
+    When calendar instances are registered this way, they do not support runtime modifications, as this requires
+    an extended calendar class.
+
+### Calendar classes
+
+When registering a plain exchange calendar *class*, it is automatically extended.
+
+```python
+import exchange_calendars as ec
+import exchange_calendars_extensions as ecx
+
+klass = ec.get_calendar("XLON").__class__  # Plain calendar class.
+
+assert issubclass(klass, ec.ExchangeCalendar)
+assert not issubclass(klass, ecx.ExtendedExchangeCalendar)
+
+ecx.apply_extensions()
+
+# Register the class under a different name.
+ec.register_calendar_type("TEST", klass)
+
+c = ec.get_calendar("TEST")
+
+assert isinstance(c, ec.ExchangeCalendar)
+assert isinstance(c, ecx.ExtendedExchangeCalendar)
+assert len(c.quarterly_expiries.rules) == 0  # Should not have quarterly expiries.
+
+ecx.remove_extensions()
+
+c = ec.get_calendar("TEST")
+
+assert isinstance(c, ec.ExchangeCalendar)
+assert not isinstance(c, ecx.ExtendedExchangeCalendar)
+```
+
+Note that after the call to `remove_extensions()`, the original class is recovered.
+
+### Extension specifications
+
+Most of the extended properties and behaviors of extended exchange calendars are added automatically. However, optional
+features like expiry day calendars require additional specification per calendar class. If undefined for an exchange,
+these optional features are not added when extending the class.
+
+To register a new specification for optional features, call `register_extension()` before registering a new calendar
+class.
+
+```python
+import exchange_calendars as ec
+import exchange_calendars_extensions as ecx
+
+klass = ec.get_calendar("XLON").__class__  # Plain calendar class.
+
+ecx.register_extension("TEST", day_of_week_expiry=4)
+
+ecx.apply_extensions()
+
+# Register the class under a different name.
+ec.register_calendar_type("TEST", klass)
+
+c = ec.get_calendar("TEST")
+
+assert isinstance(c, ec.ExchangeCalendar)
+assert isinstance(c, ecx.ExtendedExchangeCalendar)
+assert len(c.quarterly_expiries.rules) > 0  # Should have quarterly expiries.
+```
+
+### Extended calendar classes
+
+It is possible to create an extended calendar class manually. The helper function `extend_class()` creates an extended
+calendar class from any existing exchange calendar class. Extended classes can be registered with
+`register_calendar_type()` as usual.
+
+```python
+import exchange_calendars as ec
+import exchange_calendars_extensions as ecx
 from exchange_calendars.exchange_calendar_xlon import XLONExchangeCalendar
-from exchange_calendars_extensions import extend_class
 
-xlon_extended_cls = extend_class(XLONExchangeCalendar, day_of_week_expiry=4)
+klass = ecx.extend_class(XLONExchangeCalendar, day_of_week_expiry=4)
+
+ecx.apply_extensions()
+
+ec.register_calendar_type("TEST", klass)
+
+c = ec.get_calendar("TEST")
+
+assert isinstance(c, ec.ExchangeCalendar)
+assert isinstance(c, ecx.ExtendedExchangeCalendar)
+assert len(c.quarterly_expiries.rules) > 0  # Should have quarterly expiries.
 ```
 
-- The first argument is the base exchange calendar class to extend.
-- `day_of_week_expiry` (optional, defaults to `None`) is the weekday on which expiry days are normally observed
-  (Monday = 0 … Friday = 4). When set to `None`, the exchange is assumed not to support monthly or quarterly expiry
-  days and the corresponding calendars will not be added.
+!!! note
 
-The returned class inherits directly from the base class and adds the extended attributes (`holidays_all`,
-`quarterly_expiries`, etc.). It also supports runtime modifications via `change_day(...)`.
-
-### Registering a new extension
-
-To register a new extended class before activating extensions, use `register_extension()`:
-
-```python
-from exchange_calendars_extensions import register_extension, apply_extensions
-
-register_extension("XLON", day_of_week_expiry=4)
-apply_extensions()
-...
-```
-
-The `key` should be the canonical exchange name (not an alias) under which the calendar is registered with the
-`exchange_calendars` package.
+    Manualy created extended exchange calendar classes support runtime modifications through `change_day()` just as any
+    other calendar class *after* registration.
 
 ## Merging holiday calendars
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,7 @@ assert not isinstance(calendar, ecx.ExchangeCalendarExtensions)
 
 <div class="grid cards" markdown>
 
+- :lucide-watch: **[Dates & Times](datetime.md)** — Specify dates and times conveniently.
 - :lucide-calendar-plus: **[Extended properties](properties.md)** — Aggregate calendars, expiry days, last trading
   days, and more.
 - :lucide-square-pen: **[Calendar changes](changes.md)** — Modify any day at runtime: add holidays, change open/close

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,7 @@ Adds the following features to exchange calendars.
 
 **Select exchanges:**
 
-- Calendars for monthly and quarterly expiry days (quadruple witching).
-
-See the list of [supported exchanges](exchanges.md).
+- Calendars for monthly and quarterly expiry days (quadruple witching); see [supported exchanges](exchanges.md).
 
 ## Installation
 

--- a/src/exchange_calendars_extensions/__init__.py
+++ b/src/exchange_calendars_extensions/__init__.py
@@ -1,13 +1,14 @@
 import functools
 from collections.abc import Callable
-from typing import Annotated, Concatenate, Literal
+from typing import Concatenate, Literal
 
 from exchange_calendars import (
+    ExchangeCalendar,
     calendar_utils,
     get_calendar_names,
     register_calendar_type,
 )
-from pydantic import BaseModel, Field, validate_call
+from pydantic import validate_call
 from typing_extensions import ParamSpec
 
 from .changes import (
@@ -26,60 +27,11 @@ from .datetime import (
     DateLike,
     DateLikeInput,
 )
-from .holiday_calendar import (
-    ExchangeCalendarExtensions,
-    ExtendedExchangeCalendar,
-    extend_class,
-)
+from .extension import ExtensionSpec
+from .holiday_calendar import ExchangeCalendarExtensions, ExtendedExchangeCalendar
+from .holiday_calendar import extend_class as extend_class_internal
+from .state import get_state
 from .util import copy_changeset
-
-# Dictionary that maps from exchange key to ConsolidatedChangeSet. Contains all changesets to apply when creating a new
-# calendar instance. This dictionary should only ever contain non-empty changesets. If a changeset becomes empty, the
-# corresponding entry should just be removed.
-_changesets: dict[str, ConsolidatedChangeSet] = {}
-
-
-WeekDayInt = Annotated[int, Field(ge=0, le=6)]
-
-
-class ExtensionSpec(BaseModel, arbitrary_types_allowed=True):
-    """Specifies how to derive an extended calendar class from a vanilla calendar class."""
-
-    # The day of the week on which options expire. If None, expiry days are not supported.
-    day_of_week_expiry: WeekDayInt | None = None
-
-
-# Internal dictionary that specifies how to derive extended calendars for specific exchanges.
-_extensions: dict[str, ExtensionSpec] = {
-    "ASEX": ExtensionSpec(day_of_week_expiry=4),
-    "XAMS": ExtensionSpec(day_of_week_expiry=4),
-    "XBRU": ExtensionSpec(day_of_week_expiry=4),
-    "XBUD": ExtensionSpec(day_of_week_expiry=4),
-    "XCSE": ExtensionSpec(day_of_week_expiry=4),
-    "XDUB": ExtensionSpec(day_of_week_expiry=4),
-    "XETR": ExtensionSpec(day_of_week_expiry=4),
-    "XHEL": ExtensionSpec(day_of_week_expiry=4),
-    "XIST": ExtensionSpec(day_of_week_expiry=4),
-    "XJSE": ExtensionSpec(day_of_week_expiry=3),
-    "XLIS": ExtensionSpec(day_of_week_expiry=4),
-    "XLON": ExtensionSpec(day_of_week_expiry=4),
-    "XMAD": ExtensionSpec(day_of_week_expiry=4),
-    "XMIL": ExtensionSpec(day_of_week_expiry=4),
-    "XNYS": ExtensionSpec(day_of_week_expiry=4),
-    "XOSL": ExtensionSpec(day_of_week_expiry=4),
-    "XPAR": ExtensionSpec(day_of_week_expiry=4),
-    "XPRA": ExtensionSpec(day_of_week_expiry=4),
-    "XSTO": ExtensionSpec(day_of_week_expiry=4),
-    "XSWX": ExtensionSpec(day_of_week_expiry=4),
-    "XTAE": ExtensionSpec(day_of_week_expiry=4),
-    "XTSE": ExtensionSpec(day_of_week_expiry=4),
-    "XWAR": ExtensionSpec(day_of_week_expiry=4),
-    "XWBO": ExtensionSpec(day_of_week_expiry=4),
-}
-
-
-# Internal dictionary containing the original calendar classes.
-_original_classes = dict()
 
 
 def apply_extensions() -> None:
@@ -90,12 +42,13 @@ def apply_extensions() -> None:
 
     This function is idempotent. If extensions have already been applied, this function does nothing.
     """
-    if len(_original_classes) > 0:
+
+    if len(get_state().original_classes) > 0:
         # Extensions have already been applied.
         return
 
-    # Get all calendar names, including aliases.
-    calendar_names = set(get_calendar_names())
+    import exchange_calendars as ec
+    import exchange_calendars.calendar_utils as ecu
 
     def get_changeset_fn(name: str) -> Callable[[], ConsolidatedChangeSet | None]:
         """Returns a function that returns the changeset for the given exchange key.
@@ -112,23 +65,67 @@ def apply_extensions() -> None:
         """
 
         def fn() -> ConsolidatedChangeSet | None:
-            cs = _changesets.get(name)
+            cs = get_state().changesets.get(name)
             return cs
 
         return fn
 
+    register_calendar_type_orig = ecu.register_calendar_type
+
+    def _register_calendar_type(name, calendar_type, force=False):
+        # The extended class to actually register.
+        t: type[ExtendedExchangeCalendar] | None = None
+
+        if force or not ecu.global_calendar_dispatcher.has_calendar(name):
+            # Only set up extended class if upstream method will succeed.
+            if issubclass(calendar_type, ExtendedExchangeCalendar):
+                # Already an extended class.
+                t = calendar_type
+            else:
+                # Create extended class.
+                if name in get_state().extensions:
+                    t = extend_class_internal(
+                        calendar_type,
+                        day_of_week_expiry=get_state()
+                        .extensions[name]
+                        .day_of_week_expiry,
+                        changeset_provider=lambda self: get_state().changesets.get(
+                            name
+                        ),
+                    )
+                else:
+                    t = extend_class_internal(
+                        calendar_type,
+                        day_of_week_expiry=None,
+                        changeset_provider=lambda self: get_state().changesets.get(
+                            name
+                        ),
+                    )
+
+        register_calendar_type_orig(name, t, force)
+        get_state().original_classes[name] = calendar_type
+
+    ecu.register_calendar_type = _register_calendar_type
+    ec.register_calendar_type = _register_calendar_type
+    get_state().register_calendar_type_orig = register_calendar_type_orig
+
+    # Get all calendar names, including aliases.
+    calendar_names = set(get_calendar_names())
+
     # Create and register extended calendar classes for all calendars for which no explicit rules have been defined.
-    for k in calendar_names - set(_extensions.keys()):
+    for k in calendar_names - set(get_state().extensions.keys()):
         # Get the original class.
         cls = calendar_utils.global_calendar_dispatcher._calendar_factories.get(k)
 
         if cls is not None:
             # Store the original class for later use.
-            _original_classes[k] = cls
+            get_state().original_classes[k] = cls
 
             # Create extended class without support for expiry days.
-            cls = extend_class(
-                cls, day_of_week_expiry=None, changeset_provider=get_changeset_fn(k)
+            cls = extend_class_internal(
+                cls,
+                day_of_week_expiry=None,
+                changeset_provider=lambda self: get_state().changesets.get(k),
             )
 
             # Register extended class.
@@ -138,7 +135,7 @@ def apply_extensions() -> None:
             _remove_calendar_from_factory_cache(k)
 
     # Create and register extended calendar classes for all calendars for which explicit rules have been defined.
-    for k, v in _extensions.items():
+    for k, v in get_state().extensions.items():
         # Get the original class.
         cls = calendar_utils.global_calendar_dispatcher._calendar_factories.get(k)
 
@@ -147,13 +144,13 @@ def apply_extensions() -> None:
             day_of_week_expiry = v.day_of_week_expiry
 
             # Store the original class for later use.
-            _original_classes[k] = cls
+            get_state().original_classes[k] = cls
 
             # Create extended class with support for expiry days.
-            cls = extend_class(
+            cls = extend_class_internal(
                 cls,
                 day_of_week_expiry=day_of_week_expiry,
-                changeset_provider=get_changeset_fn(k),
+                changeset_provider=lambda self: get_state().changesets.get(k),
             )
 
             # Register extended class.
@@ -169,11 +166,11 @@ def remove_extensions() -> None:
 
     This removes all extended calendars from exchange_calendars, restoring the respective vanilla calendars.
     """
-    if len(_original_classes) == 0:
+    if len(get_state().original_classes) == 0:
         # Extensions have not been applied.
         return
 
-    for k, v in _original_classes.items():
+    for k, v in get_state().original_classes.items():
         # Register original class.
         register_calendar_type(k, v, force=True)
 
@@ -181,7 +178,15 @@ def remove_extensions() -> None:
         _remove_calendar_from_factory_cache(k)
 
     # Clear original classes.
-    _original_classes.clear()
+    get_state().original_classes.clear()
+
+    import exchange_calendars as ec
+    import exchange_calendars.calendar_utils as ecu
+
+    ecu.register_calendar_type = get_state().register_calendar_type_orig
+    ec.register_calendar_type = get_state().register_calendar_type_orig
+
+    get_state().register_calendar_type_orig = None
 
 
 def register_extension(name: str, day_of_week_expiry: int | None = None) -> None:
@@ -203,7 +208,7 @@ def register_extension(name: str, day_of_week_expiry: int | None = None) -> None
     -------
     None
     """
-    _extensions[name] = ExtensionSpec(day_of_week_expiry=day_of_week_expiry)
+    get_state().extensions[name] = ExtensionSpec(day_of_week_expiry=day_of_week_expiry)
 
 
 def _remove_calendar_from_factory_cache(name: str):
@@ -249,17 +254,17 @@ def _with_changeset(
     @functools.wraps(f)
     def wrapper(exchange: str, *args: P.args, **kwargs: P.kwargs) -> None:
         # Retrieve changeset for key, create new empty one, if required.
-        cs: ConsolidatedChangeSet = _changesets.get(exchange, {})
+        cs: ConsolidatedChangeSet = get_state().changesets.get(exchange, {})
 
         # Call wrapped function with changeset as first positional argument.
         cs = f(cs, *args, **kwargs)
 
         if cs:
             # Save changeset back to _changesets.
-            _changesets[exchange] = cs
+            get_state().changesets[exchange] = cs
         else:
             # Remove changeset from _changesets.
-            _changesets.pop(exchange, None)
+            get_state().changesets.pop(exchange, None)
 
         # Remove calendar for exchange key from factory cache.
         _remove_calendar_from_factory_cache(exchange)
@@ -393,9 +398,9 @@ def get_changes(exchange: str | None = None) -> ChangeSet | dict[str, ChangeSet]
         The changeset for the given exchange, or None, if no changes have been registered.
     """
     if exchange is None:
-        return {k: copy_changeset(v) for k, v in _changesets.items()}  # ty:ignore[invalid-argument-type]
+        return {k: copy_changeset(v) for k, v in get_state().changesets.items()}  # ty:ignore[invalid-argument-type]
     else:
-        cs: ChangeSet | None = _changesets.get(exchange, None)  # ty:ignore[invalid-assignment]
+        cs: ChangeSet | None = get_state().changesets.get(exchange, None)  # ty:ignore[invalid-assignment]
         return copy_changeset(cs) if cs else None
 
 
@@ -409,13 +414,21 @@ def remove_changes(exchange: str | None = None) -> None:
     """
     if exchange is None:
         # Clear the dict of changesets.
-        for k in _changesets.keys():
+        for k in get_state().changesets.keys():
             _remove_calendar_from_factory_cache(k)
-        _changesets.clear()
+        get_state().changesets.clear()
     else:
-        cs = _changesets.pop(exchange, None)
+        cs = get_state().changesets.pop(exchange, None)
         if cs:
             _remove_calendar_from_factory_cache(exchange)
+
+
+def extend_class(cls: type[ExchangeCalendar], day_of_week_expiry: int | None = None):
+    return extend_class_internal(
+        cls,
+        day_of_week_expiry=day_of_week_expiry,
+        changeset_provider=None,
+    )
 
 
 # Declare public names.
@@ -423,7 +436,6 @@ __all__ = [
     "apply_extensions",
     "remove_extensions",
     "register_extension",
-    "extend_class",
     "change_day",
     "change_calendar",
     "get_changes",
@@ -435,4 +447,5 @@ __all__ = [
     "DayChange",
     "BusinessDaySpec",
     "NonBusinessDaySpec",
+    "extend_class",
 ]

--- a/src/exchange_calendars_extensions/extension.py
+++ b/src/exchange_calendars_extensions/extension.py
@@ -1,0 +1,12 @@
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+WeekDayInt = Annotated[int, Field(ge=0, le=6)]
+
+
+class ExtensionSpec(BaseModel, arbitrary_types_allowed=True):
+    """Specifies how to derive an extended calendar class from a vanilla calendar class."""
+
+    # The day of the week on which options expire. If None, expiry days are not supported.
+    day_of_week_expiry: WeekDayInt | None = None

--- a/src/exchange_calendars_extensions/holiday_calendar.py
+++ b/src/exchange_calendars_extensions/holiday_calendar.py
@@ -28,9 +28,9 @@ from pydantic import ConfigDict, Field, TypeAdapter, validate_call
 from pydantic.experimental.missing_sentinel import MISSING
 
 from .changes import (
-    CLEAR,
     BusinessDaySpec,
     ChangeSet,
+    Clear,
     DayChange,
     NonBusinessDaySpec,
 )
@@ -801,13 +801,13 @@ class ExtendedExchangeCalendar(ExchangeCalendarExtensions, ExchangeCalendar, ABC
     Abstract base class for exchange calendars with extended functionality.
     """
 
-    _changeset_provider: Callable[[Any], ChangeSet | CLEAR | None] | None = None
+    _changeset_provider: Callable[[Any], ChangeSet | Clear | None] | None = None
 
 
 def extend_class(
     cls: type[ExchangeCalendar],
     day_of_week_expiry: int | None = None,
-    changeset_provider: Callable[[Any], ChangeSet | CLEAR | None] | None = None,
+    changeset_provider: Callable[[Any], ChangeSet | Clear | None] | None = None,
 ) -> type[ExtendedExchangeCalendar]:
     """
     Extend the given ExchangeCalendar class with additional properties.

--- a/src/exchange_calendars_extensions/holiday_calendar.py
+++ b/src/exchange_calendars_extensions/holiday_calendar.py
@@ -28,6 +28,7 @@ from pydantic import ConfigDict, Field, TypeAdapter, validate_call
 from pydantic.experimental.missing_sentinel import MISSING
 
 from .changes import (
+    CLEAR,
     BusinessDaySpec,
     ChangeSet,
     DayChange,
@@ -800,14 +801,14 @@ class ExtendedExchangeCalendar(ExchangeCalendarExtensions, ExchangeCalendar, ABC
     Abstract base class for exchange calendars with extended functionality.
     """
 
-    ...
+    _changeset_provider: Callable[[Any], ChangeSet | CLEAR | None] | None = None
 
 
 def extend_class(
     cls: type[ExchangeCalendar],
     day_of_week_expiry: int | None = None,
-    changeset_provider: Callable[[], ChangeSet | None] | None = None,
-) -> type:
+    changeset_provider: Callable[[Any], ChangeSet | CLEAR | None] | None = None,
+) -> type[ExtendedExchangeCalendar]:
     """
     Extend the given ExchangeCalendar class with additional properties.
 
@@ -817,7 +818,7 @@ def extend_class(
         The input class to extend.
     day_of_week_expiry : Union[int, None]
         The day of the week when expiry days are observed, where 0 is Monday and 6 is Sunday. Defaults to 4 (Friday).
-    changeset_provider : Union[Callable[[], ChangeSet], None]
+    changeset_provider : Union[Callable[[Any], ChangeSet], None]
         The optional function that returns a changeset to apply to the calendar.
 
     Returns
@@ -1299,7 +1300,7 @@ def extend_class(
         )
 
         changeset: ChangeSet | None = (
-            changeset_provider() if changeset_provider is not None else None
+            self._changeset_provider() if self._changeset_provider is not None else None
         )
 
         self._adjusted_properties = a
@@ -1721,6 +1722,7 @@ def extend_class(
             "last_regular_trading_days_of_months": last_regular_trading_days_of_months,
             "day": day,
             "tags": tags,
+            "_changeset_provider": changeset_provider,
         },
     )
 

--- a/src/exchange_calendars_extensions/state.py
+++ b/src/exchange_calendars_extensions/state.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+from collections.abc import Callable
+
+from .changes import ConsolidatedChangeSet
+from .extension import ExtensionSpec
+from .holiday_calendar import ExtendedExchangeCalendar
+
+
+@dataclass
+class _State:
+    # Dictionary that maps from exchange key to ConsolidatedChangeSet. Contains all changesets to apply when creating a new
+    # calendar instance. This dictionary should only ever contain non-empty changesets. If a changeset becomes empty, the
+    # corresponding entry should just be removed.
+    changesets: dict[str, ConsolidatedChangeSet] = field(default_factory=dict)
+    # Internal dictionary containing the original calendar classes.
+    original_classes: dict[str, type[ExtendedExchangeCalendar]] = field(
+        default_factory=dict
+    )
+    extensions: dict[str, ExtensionSpec] = field(
+        default_factory=lambda: {
+            "ASEX": ExtensionSpec(day_of_week_expiry=4),
+            "XAMS": ExtensionSpec(day_of_week_expiry=4),
+            "XBRU": ExtensionSpec(day_of_week_expiry=4),
+            "XBUD": ExtensionSpec(day_of_week_expiry=4),
+            "XCSE": ExtensionSpec(day_of_week_expiry=4),
+            "XDUB": ExtensionSpec(day_of_week_expiry=4),
+            "XETR": ExtensionSpec(day_of_week_expiry=4),
+            "XHEL": ExtensionSpec(day_of_week_expiry=4),
+            "XIST": ExtensionSpec(day_of_week_expiry=4),
+            "XJSE": ExtensionSpec(day_of_week_expiry=3),
+            "XLIS": ExtensionSpec(day_of_week_expiry=4),
+            "XLON": ExtensionSpec(day_of_week_expiry=4),
+            "XMAD": ExtensionSpec(day_of_week_expiry=4),
+            "XMIL": ExtensionSpec(day_of_week_expiry=4),
+            "XNYS": ExtensionSpec(day_of_week_expiry=4),
+            "XOSL": ExtensionSpec(day_of_week_expiry=4),
+            "XPAR": ExtensionSpec(day_of_week_expiry=4),
+            "XPRA": ExtensionSpec(day_of_week_expiry=4),
+            "XSTO": ExtensionSpec(day_of_week_expiry=4),
+            "XSWX": ExtensionSpec(day_of_week_expiry=4),
+            "XTAE": ExtensionSpec(day_of_week_expiry=4),
+            "XTSE": ExtensionSpec(day_of_week_expiry=4),
+            "XWAR": ExtensionSpec(day_of_week_expiry=4),
+            "XWBO": ExtensionSpec(day_of_week_expiry=4),
+        }
+    )
+    register_calendar_type_orig: Callable | None = None
+
+
+_state = _State()
+
+
+def get_state() -> _State:
+    return _state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ def run_test_in_separate_process(test_function: Callable) -> Callable:
     """
 
     def wrapper(*args, **kwargs):
-        with multiprocessing.Pool(1) as pool:
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(1) as pool:
             result = pool.apply(test_function, args, kwargs)
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 # conftest.py
 import multiprocessing
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import cast
-from collections.abc import Generator
 
 import exchange_calendars as ec
 import pytest
+from exchange_calendars import ExchangeCalendar
 
 from exchange_calendars_extensions import ExtendedExchangeCalendar
-from tests.synthetic_calendar import add_test_calendar
+from tests.synthetic_calendar import TEST_CALENDAR_CLASS_DEFAULT, add_test_calendar
 
 
 def run_test_in_separate_process(test_function: Callable) -> Callable:
@@ -57,3 +57,8 @@ def pytest_pyfunc_call(pyfuncitem):
 def test_calendar() -> Generator[ExtendedExchangeCalendar]:
     add_test_calendar()
     yield cast(ExtendedExchangeCalendar, ec.get_calendar("TEST"))
+
+
+@pytest.fixture
+def plain_test_calendar_class() -> Generator[type[ExchangeCalendar]]:
+    yield TEST_CALENDAR_CLASS_DEFAULT

--- a/tests/synthetic_calendar.py
+++ b/tests/synthetic_calendar.py
@@ -96,7 +96,7 @@ def create_test_calendar_class(
 
         @property
         def adhoc_holidays(self):
-            return adhoc_holidays if adhoc_holidays else []
+            return list(adhoc_holidays) if adhoc_holidays else []
 
         @property
         def special_closes(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,11 +4,12 @@ from typing import Any, Literal, cast
 import exchange_calendars as ec
 import pandas as pd
 import pytest
+from exchange_calendars.errors import CalendarNameCollision
 from exchange_calendars.exchange_calendar import HolidayCalendar
 from pydantic.experimental.missing_sentinel import MISSING
 
 import exchange_calendars_extensions as ecx
-from exchange_calendars_extensions import ExtendedExchangeCalendar
+from exchange_calendars_extensions import ExtendedExchangeCalendar, extend_class
 from exchange_calendars_extensions.changes import (
     BusinessDaySpec,
     DayChange,
@@ -34,6 +35,7 @@ from tests.synthetic_calendar import (
     SPECIAL_OPEN_ADHOC_DT,
     SPECIAL_OPEN_REGULAR_DT,
     SPECIAL_OPEN_REGULAR_NAME,
+    TEST_CALENDAR_CLASS_DEFAULT,
     WEEKEND_DAY_DT,
     add_extended_calendar_class,
     create_test_calendar_class,
@@ -1428,3 +1430,148 @@ class TestTags:
         assert len(result) == expected_len
         for date, expected_tags in expected_tag_values.items():
             assert result[date] == expected_tags
+
+
+class TestRegisterCalendarType:
+    @pytest.mark.isolated
+    def test_register_plain_calendar_instance(self):
+        ecx.apply_extensions()
+
+        # Register plain calendar class.
+        ec.register_calendar("TEST", TEST_CALENDAR_CLASS_DEFAULT())
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should be an extended calendar.
+        assert not isinstance(c, ExtendedExchangeCalendar)
+
+        ecx.remove_extensions()
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should still not be an extended calendar.
+        assert not isinstance(c, ExtendedExchangeCalendar)
+
+    @pytest.mark.isolated
+    def test_register_plain_calendar_type(self):
+        ecx.apply_extensions()
+
+        # Register plain calendar class.
+        ec.register_calendar_type("TEST", TEST_CALENDAR_CLASS_DEFAULT)
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should be an extended calendar.
+        assert isinstance(c, ExtendedExchangeCalendar)
+
+        # Should have (empty) expiry day calendars.
+        assert c.quarterly_expiries is not None
+        assert c.monthly_expiries is not None
+
+        ecx.remove_extensions()
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should no longer be an extended calendar.
+        assert not isinstance(c, ExtendedExchangeCalendar)
+
+    @pytest.mark.isolated
+    def test_register_plain_calendar_type_with_extension(self):
+        ecx.register_extension("TEST", day_of_week_expiry=4)
+
+        ecx.apply_extensions()
+
+        # Register plain calendar class.
+        ec.register_calendar_type("TEST", TEST_CALENDAR_CLASS_DEFAULT)
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should be an extended calendar.
+        assert isinstance(c, ExtendedExchangeCalendar)
+
+        # Should have expiry day calendars.
+        assert c.quarterly_expiries is not None
+        assert c.monthly_expiries is not None
+
+        ecx.remove_extensions()
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should no longer be an extended calendar.
+        assert not isinstance(c, ExtendedExchangeCalendar)
+
+    @pytest.mark.isolated
+    def test_register_extended_calendar_type(self):
+        ecx.apply_extensions()
+
+        # Register extended calendar class.
+        ec.register_calendar_type(
+            "TEST", extend_class(TEST_CALENDAR_CLASS_DEFAULT, day_of_week_expiry=4)
+        )
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should be an extended calendar.
+        assert isinstance(c, ExtendedExchangeCalendar)
+
+        # Should have expiry day calendars.
+        assert c.quarterly_expiries is not None
+        assert c.monthly_expiries is not None
+
+        ecx.remove_extensions()
+
+        c = ec.get_calendar("TEST")
+
+        # Should be an instance of the plain class.
+        assert isinstance(c, TEST_CALENDAR_CLASS_DEFAULT)
+
+        # Should still be an extended calendar.
+        assert isinstance(c, ExtendedExchangeCalendar)
+
+        # Should still have expiry day calendars.
+        assert c.quarterly_expiries is not None
+        assert c.monthly_expiries is not None
+
+    @pytest.mark.isolated
+    def test_register_calendar_type_name_collision(self):
+        # Register plain calendar class.
+        ec.register_calendar_type("TEST", TEST_CALENDAR_CLASS_DEFAULT)
+
+        ecx.apply_extensions()
+
+        with pytest.raises(CalendarNameCollision):
+            # Register plain calendar class.
+            ec.register_calendar_type("TEST", TEST_CALENDAR_CLASS_DEFAULT)
+
+    @pytest.mark.isolated
+    def test_register_calendar_type_alias_collision(self):
+        # Register plain calendar class.
+        ec.register_calendar_type("TEST", TEST_CALENDAR_CLASS_DEFAULT)
+        ec.register_calendar_alias("foobar", "TEST")
+
+        ecx.apply_extensions()
+
+        with pytest.raises(CalendarNameCollision):
+            # Register plain calendar class.
+            ec.register_calendar_type("foobar", TEST_CALENDAR_CLASS_DEFAULT)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1433,6 +1433,10 @@ class TestTags:
 
 
 class TestRegisterCalendarType:
+    @pytest.fixture(autouse=True)
+    def log_exchange_names(self):
+        print([x for x in ec.get_calendar_names() if x == "TEST"])
+
     @pytest.mark.isolated
     def test_register_plain_calendar_instance(self):
         ecx.apply_extensions()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1433,10 +1433,6 @@ class TestTags:
 
 
 class TestRegisterCalendarType:
-    @pytest.fixture(autouse=True)
-    def log_exchange_names(self):
-        print([x for x in ec.get_calendar_names() if x == "TEST"])
-
     @pytest.mark.isolated
     def test_register_plain_calendar_instance(self):
         ecx.apply_extensions()


### PR DESCRIPTION
This PR adds code to intercept new exchange calendar class registrations after `apply_extensions()` has been called. This allows to automatically extend newly registered classes. It also allows to reinstante the original class if `remove_extensions()` is called.