### PR TITLE
Fix late-binding closure in apply_extensions() dropping change_day registrations

### DIFF
--- a/src/exchange_calendars_extensions/__init__.py
+++ b/src/exchange_calendars_extensions/__init__.py
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Callable
-from typing import Concatenate, Literal
+from typing import Any, Concatenate, Literal
 
 from exchange_calendars import (
     ExchangeCalendar,
@@ -109,6 +109,19 @@ def apply_extensions() -> None:
     ec.register_calendar_type = _register_calendar_type
     get_state().register_calendar_type_orig = register_calendar_type_orig
 
+    def make_changeset_provider(
+        name: str,
+    ) -> Callable[[Any], ConsolidatedChangeSet | None]:
+        """Return a ``_changeset_provider`` that looks up the given calendar name.
+
+        The factory is required because the two loops below both bind a
+        free variable ``k`` in a closure. Python closures capture by
+        reference, so without this factory every provider would resolve
+        ``k`` at call time to the last value iterated by the enclosing
+        loops and fetch the wrong (or no) change-set.
+        """
+        return lambda self: get_state().changesets.get(name)
+
     # Get all calendar names, including aliases.
     calendar_names = set(get_calendar_names())
 
@@ -125,7 +138,7 @@ def apply_extensions() -> None:
             cls = extend_class_internal(
                 cls,
                 day_of_week_expiry=None,
-                changeset_provider=lambda self: get_state().changesets.get(k),
+                changeset_provider=make_changeset_provider(k),
             )
 
             # Register extended class.
@@ -150,7 +163,7 @@ def apply_extensions() -> None:
             cls = extend_class_internal(
                 cls,
                 day_of_week_expiry=day_of_week_expiry,
-                changeset_provider=lambda self: get_state().changesets.get(k),
+                changeset_provider=make_changeset_provider(k),
             )
 
             # Register extended class.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,6 +71,51 @@ def test_apply_extensions():
 
 
 @pytest.mark.isolated
+def test_change_day_reaches_non_pre_registered_calendar():
+    """Regression: change_day() on a calendar that has not been set up via
+    register_extension() must still reach its extended calendar class.
+
+    Before the factory-based fix in apply_extensions() the
+    ``_changeset_provider`` lambda captured the for-loop variable ``k``
+    by reference. Every provider therefore resolved ``k`` at call time
+    to the last value iterated by the second loop (typically
+    ``"XWBO"``), so the change-set registered under, e.g., ``"CMES"``
+    never materialised on the CMES calendar class.
+    """
+    ecx.change_day(
+        "CMES",
+        "2025-06-19",
+        ecx.DayChange(
+            spec=NonBusinessDaySpec(holiday=True),
+            name="Juneteenth",
+        ),
+    )
+
+    ecx.apply_extensions()
+
+    c = ec.get_calendar("CMES")
+    assert isinstance(c, ecx.ExtendedExchangeCalendar)
+
+    # Provider must resolve to the CMES change-set, not the change-set
+    # for whatever key the for-loop's free variable ``k`` ended on.
+    cs = type(c)._changeset_provider(c)
+    assert cs is not None, (
+        "CMES._changeset_provider() returned None — the lambda likely "
+        "resolved the loop variable to another key"
+    )
+    assert pd.Timestamp("2025-06-19") in cs
+
+    # And the override must be materialised on the calendar itself.
+    assert pd.Timestamp("2025-06-19") not in c.sessions
+    s = c.holidays_all.holidays(
+        start=pd.Timestamp("2025-06-19"),
+        end=pd.Timestamp("2025-06-19"),
+        return_name=True,
+    )
+    assert s.tolist() == ["Juneteenth"]
+
+
+@pytest.mark.isolated
 def test_extended_calendar_xetr():
     """Test the additional properties of the extended XETR calendar."""
     ecx.apply_extensions()


### PR DESCRIPTION
Fixes #160.

## Summary

Both `for k in ...` loops in `apply_extensions()` built `_changeset_provider` via `lambda self: get_state().changesets.get(k)`, capturing the loop variable by reference. Every provider therefore resolved `k` at call time to the last iterated value (typically `"XWBO"`), so `change_day` registrations for every other calendar were silently dropped.

Introduce an inner `make_changeset_provider(name)` factory whose parameter is scoped per call. Pass its result as `changeset_provider` in both loops. Same safe pattern that `_register_calendar_type` already uses for its `name` parameter a few lines above.

## Regression test

`tests/test_api.py::test_change_day_reaches_non_pre_registered_calendar`:

- Registers `change_day("CMES", "2025-06-19", DayChange(spec=NonBusinessDaySpec(holiday=True), name="Juneteenth"))`.
- Calls `apply_extensions()`.
- Asserts:
  - `CMES._changeset_provider(cal)` is not `None` and contains the override.
  - `pd.Timestamp("2025-06-19") not in cal.sessions`.
  - `cal.holidays_all` reports `Juneteenth` on `2025-06-19`.

Verified that the test FAILS against `develop` without the `__init__.py` change (asserts `CMES._changeset_provider() returned None`) and PASSES with the fix. Full `tests/test_api.py` suite: 999 passed locally (Python 3.14).

## Test plan

- [x] Reproducer from #160 output flips from buggy to expected.
- [x] New regression test fails on develop, passes on this branch.
- [x] Existing `tests/test_api.py` — 999 tests pass.